### PR TITLE
Explicite define innodb_log_file_size in mysql configuration.

### DIFF
--- a/profile/manifests/openstack/controller.pp
+++ b/profile/manifests/openstack/controller.pp
@@ -465,6 +465,7 @@ class profile::openstack::controller (
             'binlog_format'                   => 'ROW',
             'innodb_autoinc_lock_mode'        => '2',
             'innodb_locks_unsafe_for_binlog'  => '1',
+            'innodb_log_file_size'            => '50331648',
             'pid-file'                        => '/var/run/mysqld/mysqld.pid',
             'socket'                          => '/var/run/mysqld/mysqld.sock',
             'wsrep_provider'                  => '/usr/lib/libgalera_smm.so',


### PR DESCRIPTION
As described here
http://www.percona.com/forums/questions-discussions/percona-xtrabackup/17446-got-ib_logfile0-is-of-different-size-when-doing-stream-backup
xtrabackup used by percona State Snapshot Transfer during controller
initialization in HA environment has compiled default value for
innodb_log_file_size, and if it different then mysql server value,
process end with error. Defining this explicite in mysql configuration to the
same value as xtrabackup has should resolve problem.
