### PR TITLE
fix problems with runing rabbitmq in HA environment

### DIFF
--- a/hiera/cloud.yaml
+++ b/hiera/cloud.yaml
@@ -122,7 +122,7 @@ memcached::params::config_tmpl: 'profile/templates/ubuntu.memcached.conf.erb'
 
 nova::compute::vncproxy_protocol: 'https'
 
-rabbitmq::server::node_ip_address: "%{hiera('mgmt_ctrl_ip')}"
+rabbitmq::server::node_ip_address: "%{::ipaddress_eth0}"
 
 profile::tempest::users::keystone_user:
   'demo':

--- a/profile/manifests/openstack/api.pp
+++ b/profile/manifests/openstack/api.pp
@@ -112,4 +112,9 @@ class profile::openstack::api (
     ipaddresses       => $service_address,
     ports             => '8777',
   }
+  @@haproxy::balancermember {"rabbit-${::fqdn}":
+    listening_service => 'rabbit',
+    ipaddresses       => $service_address,
+    ports             => '5672',
+  }
 }

--- a/profile/manifests/openstack/proxy.pp
+++ b/profile/manifests/openstack/proxy.pp
@@ -146,7 +146,8 @@ class profile::openstack::proxy (
   $is_keystone_admin  = "is_keystone_admin    dst_port 35357"
   $is_ceilometer      = "is_ceilometer hdr_end(host) -i ${ceilometer_url} || dst_port 8777"
   $is_swift           = "is_swift hdr_end(host) -i ${swift_url} || dst_port 8080"
-  $acls               = [$is_horizon, $is_novnc, $is_redirect, $is_nova, $is_neutron, $is_glance, $is_cinder, $is_ec2, $is_keystone, $is_keystone_admin, $is_savanna, $is_ceilometer, $is_swift]
+  $is_rabbit          = "is_rabbit  dst_port 5672"
+  $acls               = [$is_horizon, $is_novnc, $is_redirect, $is_nova, $is_neutron, $is_glance, $is_cinder, $is_ec2, $is_keystone, $is_keystone_admin, $is_savanna, $is_ceilometer, $is_swift, $is_rabbit]
   $backends           = [
     'nova if is_nova',
     'neutron if is_neutron',
@@ -160,6 +161,7 @@ class profile::openstack::proxy (
     'savanna if is_savanna',
     'ceilometer if is_ceilometer',
     'swift if is_swift',
+    'rabbit if is_rabbit',
   ]
 
   haproxy::frontend {'openstack-public':
@@ -207,6 +209,7 @@ class profile::openstack::proxy (
         "${listen_address_mgmt}:8386",
         "${listen_address_mgmt}:8777",
         "${listen_address_mgmt}:8080",
+        "${listen_address_mgmt}:5672",
       ],
       'acl'             => $acls,
       'use_backend'     => $backends,
@@ -271,6 +274,11 @@ class profile::openstack::proxy (
     },
   }
   haproxy::backend {'swift':
+    options => {
+      'option'  => [],
+    },
+  }
+  haproxy::backend {'rabbit':
     options => {
       'option'  => [],
     },

--- a/role/manifests/openstack/controller.pp
+++ b/role/manifests/openstack/controller.pp
@@ -45,4 +45,7 @@ class role::openstack::controller {
   Class['profile::openstack::controller']
     -> Class['profile::openstack::glanceimages']
 
+  include rabbitmq
+  Class['rabbitmq::install'] -> Class['haproxy']
+
 }


### PR DESCRIPTION
Until now rabbit server bind to virtual ip address, but some
services trying to communicate with rabbit cluster using controllers ip
addresses in management network. After this change rabbit server will
listen on interfaces in mgmt network and moreover haproxy will listen on
virtual ip to forward request to rabbit cluster.
