### PR TITLE
metadata service in haproxy

### DIFF
--- a/profile/manifests/openstack/api.pp
+++ b/profile/manifests/openstack/api.pp
@@ -117,4 +117,9 @@ class profile::openstack::api (
     ipaddresses       => $service_address,
     ports             => '5672',
   }
+  @@haproxy::balancermember {"metadata-${::fqdn}":
+    listening_service => 'metadata',
+    ipaddresses       => $service_address,
+    ports             => '8775',
+  }
 }

--- a/profile/manifests/openstack/proxy.pp
+++ b/profile/manifests/openstack/proxy.pp
@@ -147,7 +147,25 @@ class profile::openstack::proxy (
   $is_ceilometer      = "is_ceilometer hdr_end(host) -i ${ceilometer_url} || dst_port 8777"
   $is_swift           = "is_swift hdr_end(host) -i ${swift_url} || dst_port 8080"
   $is_rabbit          = "is_rabbit  dst_port 5672"
-  $acls               = [$is_horizon, $is_novnc, $is_redirect, $is_nova, $is_neutron, $is_glance, $is_cinder, $is_ec2, $is_keystone, $is_keystone_admin, $is_savanna, $is_ceilometer, $is_swift, $is_rabbit]
+  $is_metadata        = "is_metadata  dst_port 8775"
+  $acls               = [
+     $is_horizon,
+     $is_novnc,
+     $is_redirect,
+     $is_nova,
+     $is_neutron,
+     $is_glance,
+     $is_cinder,
+     $is_ec2,
+     $is_keystone,
+     $is_keystone_admin,
+     $is_savanna,
+     $is_ceilometer,
+     $is_swift,
+     $is_rabbit,
+     $is_metadata,
+  ]
+
   $backends           = [
     'nova if is_nova',
     'neutron if is_neutron',
@@ -162,6 +180,7 @@ class profile::openstack::proxy (
     'ceilometer if is_ceilometer',
     'swift if is_swift',
     'rabbit if is_rabbit',
+    'metadata if is_metadata',
   ]
 
   haproxy::frontend {'openstack-public':
@@ -210,6 +229,7 @@ class profile::openstack::proxy (
         "${listen_address_mgmt}:8777",
         "${listen_address_mgmt}:8080",
         "${listen_address_mgmt}:5672",
+        "${listen_address_mgmt}:8775",
       ],
       'acl'             => $acls,
       'use_backend'     => $backends,
@@ -279,6 +299,11 @@ class profile::openstack::proxy (
     },
   }
   haproxy::backend {'rabbit':
+    options => {
+      'option'  => [],
+    },
+  }
+  haproxy::backend {'metadata':
     options => {
       'option'  => [],
     },


### PR DESCRIPTION
Fix for metadata service. In a future metadata service should be moved to each compute node.
